### PR TITLE
fix: setup_db in case of no db was available!

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("requirements.txt") as f:
 
 setup(
     name="tc-hivemind-backend",
-    version="1.1.1",
+    version="1.1.2",
     author="Mohammad Amin Dadgar, TogetherCrew",
     maintainer="Mohammad Amin Dadgar",
     maintainer_email="dadgaramin96@gmail.com",

--- a/tc_hivemind_backend/db/credentials.py
+++ b/tc_hivemind_backend/db/credentials.py
@@ -22,5 +22,6 @@ def load_postgres_credentials() -> dict[str, str]:
     credentials["password"] = os.getenv("POSTGRES_PASS", "")
     credentials["user"] = os.getenv("POSTGRES_USER", "")
     credentials["port"] = os.getenv("POSTGRES_PORT", "")
+    credentials["db_name"] = os.getenv("POSTGRES_DBNAME", "")
 
     return credentials

--- a/tc_hivemind_backend/db/postgresql.py
+++ b/tc_hivemind_backend/db/postgresql.py
@@ -8,16 +8,22 @@ class PostgresSingleton:
     _instance = None
 
     def __new__(cls, dbname: str | None, *args, **kwargs):
+        """
+        if `db_name` was `None`, connect to default database in .env
+        """
         if cls._instance is None:
             cls._instance = super().__new__(cls, *args, **kwargs)
             cls._instance.connect(dbname)
         return cls._instance
 
     def connect(self, dbname: str | None):
+        """
+        connect to postgrsql instance
+        """
         creds = load_postgres_credentials()
         try:
             self.conn = psycopg2.connect(
-                dbname=dbname,
+                dbname=dbname or creds["db_name"],
                 user=creds["user"],
                 password=creds["password"],
                 host=creds["host"],


### PR DESCRIPTION
In previous version we were connecting to the database with postgresql user but not having that database it would always raise error. So we fixed it now by connecting to the db in `.env`
Also the code flow is more readable.