### PR TITLE
fix: add QDRANT_USE_HTTPS environment variable to docker-compose test…

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -27,6 +27,7 @@ services:
       - QDRANT_HOST=qdrant
       - QDRANT_PORT=6333
       - QDRANT_API_KEY=
+      - QDRANT_USE_HTTPS=false
     networks:
       - python_service_network
     volumes:


### PR DESCRIPTION
… configuration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced the test configuration with a new environment option that disables secure (HTTPS) communications for an external service, affecting how the application interacts in testing environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->