### PR TITLE
fix: implement custom redis KVStore to ensure `get_all` method works as expected!

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("requirements.txt") as f:
 
 setup(
     name="tc-hivemind-backend",
-    version="1.4.5",
+    version="1.4.6",
     author="Mohammad Amin Dadgar, TogetherCrew",
     maintainer="Mohammad Amin Dadgar",
     maintainer_email="dadgaramin96@gmail.com",

--- a/tc_hivemind_backend/db/redis_kv_store.py
+++ b/tc_hivemind_backend/db/redis_kv_store.py
@@ -1,0 +1,50 @@
+import json
+from typing import Any, Dict
+
+from llama_index.core.storage.kvstore.types import DEFAULT_COLLECTION
+from llama_index.storage.kvstore.redis import RedisKVStore
+
+
+class CustomRedisKVStore(RedisKVStore):
+    """
+    A Redis KV store that is compatible with redis-py clients configured with
+    decode_responses=True. Overrides get_all/aget_all to avoid calling decode()
+    on str keys/values.
+    """
+
+    def get_all(self, collection: str = DEFAULT_COLLECTION) -> Dict[str, dict]:
+        collection_kv_dict: Dict[str, dict] = {}
+        for key, val_str in self._redis_client.hscan_iter(name=collection):
+            # Handle both bytes and str for key and value
+            if isinstance(key, bytes):
+                key = key.decode()
+            if isinstance(val_str, bytes):
+                val_str = val_str.decode()
+
+            value_obj = json.loads(val_str) if val_str is not None else None
+            if value_obj is not None:
+                # Ensure dict type
+                value_dict = value_obj if isinstance(value_obj, dict) else dict(value_obj)
+                collection_kv_dict[key] = value_dict
+        return collection_kv_dict
+
+    async def aget_all(self, collection: str = DEFAULT_COLLECTION) -> Dict[str, dict]:
+        collection_kv_dict: Dict[str, dict] = {}
+        async for key, val_str in self._async_redis_client.hscan_iter(name=collection):
+            if isinstance(key, bytes):
+                key = key.decode()
+            if isinstance(val_str, bytes):
+                val_str = val_str.decode()
+
+            value_obj = json.loads(val_str) if val_str is not None else None
+            if value_obj is not None:
+                value_dict = value_obj if isinstance(value_obj, dict) else dict(value_obj)
+                collection_kv_dict[key] = value_dict
+        return collection_kv_dict
+
+    @classmethod
+    def from_redis_client(cls, redis_client: Any) -> "CustomRedisKVStore":
+        # Keep parity with upstream API for convenience
+        return cls(redis_client=redis_client)
+
+

--- a/tc_hivemind_backend/ingest_qdrant.py
+++ b/tc_hivemind_backend/ingest_qdrant.py
@@ -11,7 +11,7 @@ from llama_index.core.ingestion import (
 from llama_index.core.node_parser import SemanticSplitterNodeParser
 from llama_index.core.schema import BaseNode
 from llama_index.storage.docstore.mongodb import MongoDocumentStore
-from llama_index.storage.kvstore.redis import RedisKVStore as RedisCache
+from tc_hivemind_backend.db.redis_kv_store import CustomRedisKVStore
 from qdrant_client.conversions import common_types as qdrant_types
 from qdrant_client.http import models
 from tc_hivemind_backend.db.credentials import Credentials
@@ -95,7 +95,7 @@ class CustomIngestionPipeline:
 
         if self.redis_client:
             cache = IngestionCache(
-                cache=RedisCache.from_redis_client(self.redis_client),
+                cache=CustomRedisKVStore.from_redis_client(self.redis_client),
                 collection=f"{self.collection_name}_ingestion_cache",
                 docstore_strategy=DocstoreStrategy.UPSERTS,
             )

--- a/tc_hivemind_backend/tests/unit/test_ingestion_pipeline.py
+++ b/tc_hivemind_backend/tests/unit/test_ingestion_pipeline.py
@@ -1,0 +1,44 @@
+import unittest
+from unittest.mock import Mock
+
+from llama_index.core.ingestion import IngestionPipeline
+from llama_index.core.schema import Document
+from tc_hivemind_backend.ingest_qdrant import CustomIngestionPipeline
+
+
+class TestIngestionPipeline(unittest.TestCase):
+    def test_run_pipeline(self):
+        ingest_pipeline = Mock(IngestionPipeline)
+        community = "1234"
+        collection_name = "google"
+        ingestion_pipeline = CustomIngestionPipeline(
+            community_id=community,
+            collection_name=collection_name,
+            testing=True,
+        )
+        docs = [
+            Document(
+                id_="b049e7cf-3279-404b-b324-9776fe1cf60b",
+                text="""A banana is an elongated""",
+            ),
+            Document(
+                id_="3b3033c0-7e37-493c-8b4c-fd51f754a59a",
+                text="""Musa species are native to tropical Indomalaya and Australia""",
+            ),
+        ]
+
+        processed_result = ingestion_pipeline.run_pipeline(docs)
+        ingest_pipeline.run.return_value = processed_result
+        self.assertEqual(len(processed_result), 2)
+
+    def test_load_pipeline_run_exception(self):
+        ingestion_pipeline = CustomIngestionPipeline(
+            "1234", collection_name="google", testing=True
+        )
+        ingestion_pipeline.run_pipeline = Mock()
+        ingestion_pipeline.run_pipeline.side_effect = Exception("Test Exception")
+        docs = ["ww"]
+        with self.assertRaises(Exception) as context:
+            ingestion_pipeline.run_pipeline(docs)
+        self.assertEqual(str(context.exception), "Test Exception")
+        ingestion_pipeline.run_pipeline.assert_called_with(docs)


### PR DESCRIPTION
Fixing the problem described here

```
  File "/home/airflow/.local/lib/python3.11/site-packages/tc_hivemind_backend/ingest_qdrant.py", line 125, in run_pipeline
    cache.clear()
  File "/home/airflow/.local/lib/python3.11/site-packages/llama_index/core/ingestion/cache.py", line 53, in clear
    data = self.cache.get_all(collection=collection)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.11/site-packages/llama_index/storage/kvstore/redis/base.py", line 161, in get_all
    collection_kv_dict[key.decode()] = value
                       ^^^^^^^^^^
AttributeError: 'str' object has no attribute 'decode'
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility and reliability of the Redis-backed ingestion cache, preventing decoding/deserialization issues across varied Redis configurations and ensuring complete retrieval in both synchronous and asynchronous ingestion flows.

* **Tests**
  * Added unit tests covering normal ingestion behavior and error propagation during pipeline runs.

* **Chores**
  * Bumped package version to 1.4.6.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->